### PR TITLE
Fix segfault invalid host

### DIFF
--- a/bti.c
+++ b/bti.c
@@ -724,6 +724,11 @@ static int send_request(struct session *session)
 				free(req_url);
 		}
 
+		if (!reply) {
+			fprintf(stderr, "Error retrieving from URL (%s)\n", endpoint);
+			return 1;
+		}
+
 		if ((session->action != ACTION_UPDATE) &&
 				(session->action != ACTION_RETWEET))
 			parse_timeline(reply, session);


### PR DESCRIPTION
Hi greg,

Please pull a fix to avoid a segfault when specifying an invalid host name via commandline.
