### PR TITLE
Color output with ANSI codes

### DIFF
--- a/bti.h
+++ b/bti.h
@@ -68,6 +68,7 @@ struct session {
 	enum host host;
 	enum action action;
 	void *readline_handle;
+	int colorize;
 	char *(*readline)(const char *);
 };
 

--- a/config.c
+++ b/config.c
@@ -268,6 +268,11 @@ static int shrink_urls_callback(struct session *session, char *value)
 	return session_bool(&session->shrink_urls, value);
 }
 
+static int colorize_callback(struct session *session, char *value)
+{
+	return session_bool(&session->colorize, value);
+}
+
 /*
  * List of all of the config file options.
  *
@@ -292,6 +297,7 @@ static struct config_function config_table[] = {
 	{ "action", action_callback },
 	{ "verbose", verbose_callback },
 	{ "shrink-urls", shrink_urls_callback },
+	{ "colorize", colorize_callback },
 	{ NULL, NULL }
 };
 


### PR DESCRIPTION
Colorize special tokens (#hashtags, @mentions, urls) with ANSI codes.
Introduce new configuration variable (colorize).
Check if output is a TTY to avoid redirecting/piping garbage.

Signed-off-by: L. Alberto Giménez agimenez@sysvalve.es

---

I gave a shot to ncurses but its ending method clears out the screen and I didn't find a way to disable that behaviour (if it is possible at all). Also, implementation with ANSI color codes is simpler and not less standard.
