### PR TITLE
Using https intead of http

### DIFF
--- a/bti.c
+++ b/bti.c
@@ -258,9 +258,9 @@ const char identica_name[] = "identi.ca";
 static const char twitter_request_token_uri[]  = "http://twitter.com/oauth/request_token";
 static const char twitter_access_token_uri[]   = "http://twitter.com/oauth/access_token";
 static const char twitter_authorize_uri[]      = "http://twitter.com/oauth/authorize?oauth_token=";
-static const char identica_request_token_uri[] = "http://identi.ca/api/oauth/request_token?oauth_callback=oob";
-static const char identica_access_token_uri[]  = "http://identi.ca/api/oauth/access_token";
-static const char identica_authorize_uri[]     = "http://identi.ca/api/oauth/authorize?oauth_token=";
+static const char identica_request_token_uri[] = "https://identi.ca/api/oauth/request_token?oauth_callback=oob";
+static const char identica_access_token_uri[]  = "https://identi.ca/api/oauth/access_token";
+static const char identica_authorize_uri[]     = "https://identi.ca/api/oauth/authorize?oauth_token=";
 
 static const char user_uri[]     = "/user_timeline/";
 static const char update_uri[]   = "/update.xml";


### PR DESCRIPTION
Apparently identi.ca in it's latest round of updates has deprecated http endpoints for OAuth stuff, this patch simply replaces http endpoints with https ones.
