### PR TITLE
Add --machine-readable switch to output tab-separated columns

### DIFF
--- a/bti.1
+++ b/bti.1
@@ -1,7 +1,7 @@
 '\" t
 .\"     Title: bti
 .\"    Author: [see the "AUTHOR" section]
-.\" Generator: DocBook XSL Stylesheets v1.78.0 <http://docbook.sf.net/>
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
 .\"      Date: May 2008
 .\"    Manual: bti
 .\"    Source: bti
@@ -31,7 +31,7 @@
 bti \- send a tweet to twitter\&.com from the command line
 .SH "SYNOPSIS"
 .HP \w'\fBbti\fR\ 'u
-\fBbti\fR [\fB\-\-account\ account\fR] [\fB\-\-password\ password\fR] [\fB\-\-action\ action\fR] [\fB\-\-user\ screenname\fR] [\fB\-\-host\ HOST_NAME\fR] [\fB\-\-proxy\ PROXY:PORT\fR] [\fB\-\-logfile\ LOGFILE\fR] [\fB\-\-config\ CONFIGFILE\fR] [\fB\-\-replyto\ ID\fR] [\fB\-\-retweet\ ID\fR] [\fB\-\-page\ PAGENUMBER\fR] [\fB\-\-bash\fR] [\fB\-\-shrink\-urls\fR] [\fB\-\-debug\fR] [\fB\-\-dry\-run\fR] [\fB\-\-verbose\fR] [\fB\-\-version\fR] [\fB\-\-help\fR]
+\fBbti\fR [\fB\-\-account\ account\fR] [\fB\-\-password\ password\fR] [\fB\-\-action\ action\fR] [\fB\-\-user\ screenname\fR] [\fB\-\-host\ HOST_NAME\fR] [\fB\-\-proxy\ PROXY:PORT\fR] [\fB\-\-logfile\ LOGFILE\fR] [\fB\-\-config\ CONFIGFILE\fR] [\fB\-\-replyto\ ID\fR] [\fB\-\-retweet\ ID\fR] [\fB\-\-page\ PAGENUMBER\fR] [\fB\-\-bash\fR] [\fB\-\-shrink\-urls\fR] [\fB\-\-debug\fR] [\fB\-\-dry\-run\fR] [\fB\-\-verbose\fR] [\fB\-\-machine\-readable\fR] [\fB\-\-version\fR] [\fB\-\-help\fR]
 .SH "DESCRIPTION"
 .PP
 bti sends a tweet message to twitter\&.com\&.
@@ -124,6 +124,11 @@ Performs all steps that would normally be done for a given action, but will not 
 Verbose mode\&. Print status IDs and timestamps\&.
 .RE
 .PP
+\fB\-\-machine\-readable\fR
+.RS 4
+Machine\-readable mode\&. Print status IDs and timestamps and separate them with tabs\&.
+.RE
+.PP
 \fB\-\-bash\fR
 .RS 4
 Add the working directory and a \*(Aq$\*(Aq in the tweet message to help specify it is coming from a command line\&. Don\*(Aqt put the working directory and the \*(Aq$\*(Aq in the tweet message\&.
@@ -154,7 +159,6 @@ Its primary focus is to allow you to log everything that you type into a bash sh
 .PP
 To hook bti up to your bash shell, export the following variable:
 .PP
-
 PROMPT_COMMAND=\*(Aqhistory 1 | sed \-e "s/^\es*[0\-9]*\es*//" | bti \-\-bash\*(Aq
 .PP
 This example assumes that you have the
@@ -215,6 +219,11 @@ Setting this variable to \*(Aqtrue\*(Aq or \*(Aqyes\*(Aq will enable the URL shr
 \fBverbose\fR
 .RS 4
 Setting this variable to \*(Aqtrue\*(Aq or \*(Aqyes\*(Aq will enable the verbose mode\&.
+.RE
+.PP
+\fBmachine\-readable\fR
+.RS 4
+Setting this variable to \*(Aqtrue\*(Aq or \*(Aqyes\*(Aq will enable the machine\-readable mode\&.
 .RE
 .PP
 There is an example config file called

--- a/bti.c
+++ b/bti.c
@@ -33,6 +33,7 @@
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <json-c/json.h>
+#include <json-c/bits.h>
 #include <pcre.h>
 #include <termios.h>
 #include <dlfcn.h>
@@ -76,6 +77,7 @@ static void display_help(void)
 		"  --background\n"
 		"  --debug\n"
 		"  --verbose\n"
+		"  --machine-readable\n"
 		"  --dry-run\n"
 		"  --version\n"
 		"  --help\n", VERSION);
@@ -357,6 +359,15 @@ static void bti_output_line(struct session *session, xmlChar *user,
 	if (session->verbose)
 		printf("[%*s] {%s} (%.16s) %s\n", -session->column_output, user,
 				id, created, text);
+	else if (session->machine_readable) {
+		char *text_no_nl = strdup((char *)text);
+		char *c = text_no_nl;
+		while((c = strchr(c, '\n')) != NULL) {
+			*c++ = ' ';
+		}
+		printf("%*s\t%s\t%.16s\t%s\n", -session->column_output, user,
+				id, created, text_no_nl);
+	}
 	else
 		printf("[%*s] %s\n", -session->column_output, user, text);
 }
@@ -1517,6 +1528,7 @@ int main(int argc, char *argv[], char *envp[])
 	static const struct option options[] = {
 		{ "debug", 0, NULL, 'd' },
 		{ "verbose", 0, NULL, 'V' },
+		{ "machine-readable", 0, NULL, 'm' },
 		{ "account", 1, NULL, 'a' },
 		{ "password", 1, NULL, 'p' },
 		{ "host", 1, NULL, 'H' },
@@ -1587,6 +1599,9 @@ int main(int argc, char *argv[], char *envp[])
 			break;
 		case 'V':
 			session->verbose = 1;
+			break;
+		case 'm':
+			session->machine_readable = 1;
 			break;
 		case 'a':
 			if (session->account)

--- a/bti.h
+++ b/bti.h
@@ -59,6 +59,7 @@ struct session {
 	int no_oauth;
 	int guest;
 	int verbose;
+	int machine_readable;
 	int column_output;
 	enum host host;
 	enum action action;

--- a/bti.xml
+++ b/bti.xml
@@ -43,6 +43,7 @@
           <arg><option>--debug</option></arg>
           <arg><option>--dry-run</option></arg>
           <arg><option>--verbose</option></arg>
+          <arg><option>--machine-readable</option></arg>
           <arg><option>--version</option></arg>
           <arg><option>--help</option></arg>
         </cmdsynopsis>
@@ -215,6 +216,14 @@
             <listitem>
               <para>
                 Verbose mode. Print status IDs and timestamps.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term><option>--machine-readable</option></term>
+            <listitem>
+              <para>
+                Machine-readable mode. Print status IDs and timestamps and separate them with tabs.
               </para>
             </listitem>
           </varlistentry>
@@ -394,6 +403,15 @@
                <para>
                    Setting this variable to 'true' or 'yes' will enable the
                    verbose mode.
+               </para>
+             </listitem>
+           </varlistentry>
+           <varlistentry>
+             <term><option>machine-readable</option></term>
+             <listitem>
+               <para>
+                   Setting this variable to 'true' or 'yes' will enable the
+                   machine-readable mode.
                </para>
              </listitem>
            </varlistentry>

--- a/config.c
+++ b/config.c
@@ -253,6 +253,11 @@ static int verbose_callback(struct session *session, char *value)
 	return session_bool(&session->verbose, value);
 }
 
+static int machine_readable_callback(struct session *session, char *value)
+{
+	return session_bool(&session->machine_readable, value);
+}
+
 static int shrink_urls_callback(struct session *session, char *value)
 {
 	return session_bool(&session->shrink_urls, value);
@@ -281,6 +286,7 @@ static struct config_function config_table[] = {
 	{ "host", host_callback },
 	{ "action", action_callback },
 	{ "verbose", verbose_callback },
+	{ "machine-readable", machine_readable_callback },
 	{ "shrink-urls", shrink_urls_callback },
 	{ NULL, NULL }
 };


### PR DESCRIPTION
I'm using bti along with a bash script and it'd be a lot easier if I could just read the tab-separated values rather than parsing the current output.

In addition to separating columns with tabs, this also removes newlines in machine-readable mode (because it's impossible to know where a tweet ends otherwise)